### PR TITLE
Fix XPath matcher spacing bug

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -42,7 +42,7 @@ public class XPathMatcher {
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
     private static final Pattern ELEMENT_WITH_CONDITION_PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)(\\[.+])");
     private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[.*?])+?");
-    private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))=[\"'](.*?)[\"'](\\h?(or|and)\\h?)?)+?");
+    private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))\\h*=\\h*[\"'](.*?)[\"'](\\h?(or|and)\\h?)?)+?");
 
     private final String expression;
     private final boolean startsWithSlash;

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
@@ -124,4 +124,22 @@ class ChangeTagAttributeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeTagAttributeAndXSDProblem() {
+        rewriteRun(
+            spec -> spec.recipe(new ChangeTagAttribute("//*[namespace-uri() = 'http://java.sun.com/xml/ns/jaxb' and local-name() = 'bindings']",
+                    "version", "3.0", "1.0", false)).expectedCyclesThatMakeChanges(0),
+
+            xml(
+                    """
+                            <schema xmlns="http://www.w3.org/2001/XMLSchema"
+                            xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            targetNamespace="http://www.w3.org/2001/04/xmlenc#"
+                            elementFormDefault="qualified" version="1.0"/>
+                            """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- allow whitespace around `=` in XPathMatcher conditions
- add regression test for ChangeTagAttribute when XPath spacing is present

The previous implementation of XPathMatcher did not correctly handle spacing, which caused predicates with whitespace around = to be ignored or misinterpreted.

This problem renders the official OpenRewrite recipe, such as org.openrewrite.java.migrate.jakarta.JavaxXmlToJakartaXmlXJCBinding, unusable. In particular, when matching attributes like version="1.0" in schemas.
